### PR TITLE
Update pom.xml

### DIFF
--- a/mip-filesdk-java-sample/pom.xml
+++ b/mip-filesdk-java-sample/pom.xml
@@ -20,22 +20,17 @@
 
   <dependencies>
 
-      <dependencies>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-          <version>1.7.28</version>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
-
+	<dependency>
+	  <groupId>org.slf4j</groupId>
+	  <artifactId>slf4j-api</artifactId>
+	  <version>1.7.28</version>
+	</dependency>
 
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>msal4j</artifactId>
       <version>1.11.0</version>
     </dependency>
-
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Malformed pom.xml breaks some editors (NetBeans) and prevents Visual Studio Code's Java extensions to load the folder properly as a Java Project (Debugger for Java, Extension pack for Java).